### PR TITLE
polishing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,8 @@ Install
 We strongly recommend installing `indicate` inside a Python virtual environment
 (see `venv documentation <https://docs.python.org/3/library/venv.html#creating-virtual-environments>`__)
 
+**Requirements:** Python 3.10 or higher
+
 ::
 
     pip install indicate
@@ -59,6 +61,40 @@ We expose 1 function, which will take Hindi text and transliterate it to English
   - Output
 
     - Returns text in English
+
+Testing Locally
+---------------
+To test the package locally, follow these steps:
+
+1. **Clone the repository**::
+
+    git clone https://github.com/in-rolls/indicate.git
+    cd indicate
+
+2. **Create and activate a virtual environment**::
+
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+3. **Install in development mode**::
+
+    pip install -e .
+
+4. **Run tests**::
+
+    # Run all tests
+    python -m unittest discover indicate/tests/
+
+    # Run specific test
+    python -m unittest indicate.tests.test_010_hindi_translate
+
+5. **Test the transliteration**::
+
+    # Command line usage
+    hindi2english --type hin2eng --input "हिंदी"
+
+    # Python usage
+    python -c "from indicate import transliterate; print(transliterate.hindi2english('हिंदी'))"
 
 Data
 ----

--- a/indicate/hindi2english.py
+++ b/indicate/hindi2english.py
@@ -1,12 +1,8 @@
 import json
 from typing import Any, List, Optional, Tuple
+from importlib.resources import files
 
 from .logging import get_logger
-
-try:
-    from importlib.resources import files
-except ImportError:
-    from importlib_resources import files
 
 import tensorflow as tf
 from func_timeout import FunctionTimedOut, func_timeout


### PR DESCRIPTION
- Remove importlib_resources backward compatibility since Python 3.10+ is required
- Add clear Python version requirement (3.10+) to README
- Add comprehensive local testing section with step-by-step instructions
- Include both unittest and CLI testing examples