### PR TITLE
Format the README's Python blocks for ruff 0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ console script is not on `PATH`.
 ```python
 import indicate
 
-indicate.transliterate("राजशेखर चिंतालपति")            # "rajshekhar chintalpati"
-indicate.transliterate("ਰਵਿ", source="punjabi")        # "ravi"
-indicate.transliterate("नमस्ते", n=3)                  # 3 ranked candidates
-indicate.transliterate_batch(["हिंदी", "मुंबई"])        # ["hindi", "mumbai"]
+indicate.transliterate("राजशेखर चिंतालपति")  # "rajshekhar chintalpati"
+indicate.transliterate("ਰਵਿ", source="punjabi")  # "ravi"
+indicate.transliterate("नमस्ते", n=3)  # 3 ranked candidates
+indicate.transliterate_batch(["हिंदी", "मुंबई"])  # ["hindi", "mumbai"]
 
-indicate.supported()          # {(source, target): (backends...)}
+indicate.supported()  # {(source, target): (backends...)}
 ```
 
 ### Choosing the engine
@@ -218,9 +218,11 @@ with checkpointing, and answers what it can locally first:
 from indicate.batch import transliterate_tokens_batched
 
 pairs = transliterate_tokens_batched(
-    tokens, "punjabi", "english",
+    tokens,
+    "punjabi",
+    "english",
     checkpoint_path="run.jsonl",
-    engine=("lookup", "llm"),      # default; ("lookup","model","llm") goes further
+    engine=("lookup", "llm"),  # default; ("lookup","model","llm") goes further
 )
 ```
 


### PR DESCRIPTION
Unblocks Dependabot #30 (ruff 0.15.22 → 0.16.2), which currently fails
`ci / lint` and so cannot auto-merge:

```
unformatted: File would be reformatted
1 file would be reformatted, 84 files already formatted
```

ruff 0.16 formats Python code blocks **inside Markdown**, which 0.15 did not.
The README's blocks were hand-aligned into a comment column; the new formatter
collapses that to a single space.

Applied rather than excluded. The alignment was never dependable — Devanagari
and Gurmukhi glyph widths vary by font, so the column only ever lined up on the
machine it was written on — and an exclude to preserve it would need
re-justifying at every future bump.

Cosmetic only. Both blocks remain valid Python, and **both** ruff 0.15.22 (the
version currently locked) and 0.16.2 (the one Dependabot proposes) accept the
result, so master is green either side of the bump.

Verified: `uv run ruff format --check .` and `uv run ruff check .` clean on
0.15.22; `uvx ruff@0.16.2 format --check .` clean; `sphinx-build -W` exit 0
(the README is included into the docs); 474 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)