### PR TITLE
Make a missing api.rst entry a test failure

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -133,3 +133,10 @@ Data resolution
 .. automodule:: indicate.resources
    :members:
    :show-inheritance:
+
+Logging
+-------
+
+.. automodule:: indicate.logging
+   :members:
+   :show-inheritance:

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -1,0 +1,78 @@
+"""The API reference must list every module, and only modules that exist.
+
+``docs/api.rst`` names each module in an explicit ``automodule`` block, and
+nothing else connects that list to the package. The two ways it can drift are
+not equally visible:
+
+* a **stale** entry is loud -- autodoc cannot import a module that was deleted,
+  and ``sphinx-build -W`` turns that into a failed build;
+* a **missing** entry is silent. Nothing references the new module, so nothing
+  complains, and it is simply absent from the published reference.
+
+That asymmetry is what this file exists for. It has already bitten twice in one
+day: ``api.rst`` pointed at the deleted ``indicate.hindi2english`` and
+``indicate.punjabi2english`` until someone noticed by eye, and
+``indicate.logging`` was missing from it entirely.
+
+Deliberately a string comparison over two directory listings rather than a
+Sphinx build: it needs no artifacts, no network and no docs dependency group,
+so it runs in the default suite on a fresh clone and fails in milliseconds
+rather than at the end of a docs build.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACKAGE = REPO_ROOT / "indicate"
+API_RST = REPO_ROOT / "docs" / "api.rst"
+
+#: Modules deliberately left out of the reference, each with a reason. Keep
+#: this empty if you can: an entry here is a promise that the module is genuinely
+#: not part of the documented surface, not a way to silence this test.
+UNDOCUMENTED: dict[str, str] = {}
+
+_AUTOMODULE = re.compile(r"^\.\.\s+automodule::\s+indicate\.(\w+)\s*$", re.M)
+
+
+def _package_modules() -> set[str]:
+    """Return every importable module name directly under ``indicate/``."""
+    return {
+        path.stem for path in PACKAGE.glob("*.py") if not path.stem.startswith("__")
+    }
+
+
+def _documented_modules() -> set[str]:
+    """Return every ``indicate.X`` named by an automodule block in api.rst."""
+    return set(_AUTOMODULE.findall(API_RST.read_text(encoding="utf-8")))
+
+
+def test_every_module_appears_in_the_api_reference():
+    missing = _package_modules() - _documented_modules() - set(UNDOCUMENTED)
+    assert not missing, (
+        f"{sorted(missing)} exist in indicate/ but have no `.. automodule::` "
+        f"block in docs/api.rst, so they are absent from the published "
+        f"reference and nothing else would have said so. Add a section, or "
+        f"add the module to UNDOCUMENTED with a reason."
+    )
+
+
+def test_the_api_reference_names_no_module_that_was_deleted():
+    stale = _documented_modules() - _package_modules()
+    assert not stale, (
+        f"docs/api.rst documents {sorted(stale)}, which no longer exist in "
+        f"indicate/. sphinx-build -W also catches this, but as an autodoc "
+        f"import traceback rather than by name."
+    )
+
+
+def test_exclusions_are_real_modules_with_stated_reasons():
+    # An exclusion for a module that no longer exists is dead weight that
+    # silently widens what the test above will tolerate.
+    unknown = set(UNDOCUMENTED) - _package_modules()
+    assert not unknown, f"UNDOCUMENTED names non-existent modules: {sorted(unknown)}"
+    assert all(reason.strip() for reason in UNDOCUMENTED.values()), (
+        "every UNDOCUMENTED entry needs a reason"
+    )


### PR DESCRIPTION
## Why

`docs/api.rst` names each module in an explicit `automodule` block, and nothing
connected that list to the package. The two drift directions are **not** equally
visible:

- a **stale** entry is loud — autodoc cannot import a deleted module, so
  `sphinx-build -W` fails the build;
- a **missing** entry is silent — nothing references the new module, so it is
  simply absent from the published reference and no check says so.

That asymmetry bit twice in one day: `api.rst` pointed at the deleted
`indicate.hindi2english` / `indicate.punjabi2english` until it was caught by
eye, and `indicate.logging` was missing entirely — which is exactly what this
test found on its first run:

```
AssertionError: ['logging'] exist in indicate/ but have no `.. automodule::`
block in docs/api.rst
```

## What

`tests/test_docs_coverage.py` asserts both directions, plus that any
`UNDOCUMENTED` exclusion names a module that really exists and states a reason
(an exclusion for a deleted module silently widens what the first assertion
tolerates). `docs/api.rst` gains the missing `indicate.logging` section.

A string comparison over two directory listings, not a Sphinx build: no
artifacts, no network, no docs dependency group, so it runs in the default suite
on a fresh clone and fails in milliseconds.

## Verified

- Red first, naming `logging`; green after adding the section.
- Proven to catch the case it exists for: added a throwaway
  `indicate/zzz_probe.py`, watched it fail **by name**, removed it, watched it
  pass.
- `sphinx-build -W` exit 0 with the new section; 477 tests pass; `ruff check`,
  `ruff format --check`, `pyright` all clean.

## Note

The docs themselves need nothing else — they are already fully automated.
README is `.. include::`d rather than copied, the API reference is
`automodule`, the version comes from package metadata, and GitHub Pages deploys
from the workflow artifact (`build_type: workflow`, no `gh-pages` branch). This
closes the one remaining manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)