### PR TITLE
Make pydoclint pass, before canon starts enforcing it

### DIFF
--- a/indicate/api.py
+++ b/indicate/api.py
@@ -18,7 +18,7 @@ the order it was given.
 from __future__ import annotations
 
 from itertools import islice
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .engine import Candidates, build, resolve_words
 from .languages import PAIRS, resolve_pair
@@ -27,6 +27,7 @@ from .transliterator import DEFAULT_BEAM
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from .llm_indic import IndicLLMTransliterator
     from .rerank import Reranker
 
 
@@ -69,8 +70,8 @@ def transliterate_batch(
     n: int = 1,
     beam: int | None = None,
     reranker: Reranker | None = None,
-    llm=None,
-    **llm_kwargs,
+    llm: IndicLLMTransliterator | None = None,
+    **llm_kwargs: Any,
 ) -> list[str] | list[list[str]]:
     """Transliterate many texts at once.
 
@@ -88,13 +89,14 @@ def transliterate_batch(
         llm: An existing ``IndicLLMTransliterator`` to reuse.
         **llm_kwargs: Provider settings for the ``llm`` backend.
 
+    Propagates ``UnsupportedPairError`` from :func:`~indicate.languages.resolve_pair`
+    when the direction cannot be detected, or when no backend in the chain
+    supports it. It is documented here rather than under ``Raises`` because
+    nothing in this body raises it directly.
+
     Returns:
         One result per input: a ``str`` each when ``n == 1``, else a list of up
         to ``n`` candidates each.
-
-    Raises:
-        UnsupportedPairError: If the direction cannot be detected, or no backend in
-            the chain supports it.
     """
     texts = list(texts)
     # Cap the number of *non-blank* texts sampled, not the number of positions
@@ -152,8 +154,8 @@ def transliterate(
     n: int = 1,
     beam: int | None = None,
     reranker: Reranker | None = None,
-    llm=None,
-    **llm_kwargs,
+    llm: IndicLLMTransliterator | None = None,
+    **llm_kwargs: Any,
 ) -> str | list[str]:
     """Transliterate one text.
 
@@ -168,13 +170,15 @@ def transliterate(
         llm: An existing ``IndicLLMTransliterator`` to reuse.
         **llm_kwargs: Provider settings for the ``llm`` backend.
 
+    Propagates ``UnsupportedPairError`` from :func:`transliterate_batch` when the
+    direction is unsupported or undetectable; it is not raised here.
+
     Returns:
         A ``str`` when ``n == 1``; a list of up to ``n`` candidates otherwise.
 
     Raises:
         TypeError: If ``text`` is ``None``.
         ValueError: If ``text`` is not a string.
-        UnsupportedPairError: If the direction is unsupported or undetectable.
     """
     if text is None:
         raise TypeError("Input cannot be None")

--- a/indicate/cli.py
+++ b/indicate/cli.py
@@ -59,7 +59,12 @@ class EngineChain(click.ParamType):
 
     name = "engine"
 
-    def convert(self, value, param, ctx) -> tuple[str, ...]:
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> tuple[str, ...]:
         """Parse and validate ``lookup,model`` into a tuple.
 
         Args:

--- a/indicate/engine.py
+++ b/indicate/engine.py
@@ -36,7 +36,7 @@ about 4x on cold start and is asserted in ``tests/test_lookup_bench.py``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from .languages import BACKENDS, Pair, UnsupportedPairError, supports
 from .logging import get_logger
@@ -44,6 +44,7 @@ from .logging import get_logger
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from .llm_indic import IndicLLMTransliterator
     from .rerank import Reranker
 
 logger = get_logger()
@@ -216,9 +217,9 @@ class LLMBackend:
         self,
         pair: Pair,
         *,
-        transliterator=None,
+        transliterator: IndicLLMTransliterator | None = None,
         group_size: int = 25,
-        **client_kwargs,
+        **client_kwargs: Any,
     ) -> None:
         """Bind to one language pair.
 
@@ -312,8 +313,8 @@ def build(
     *,
     beam: int = 5,
     reranker: Reranker | None = None,
-    llm=None,
-    **llm_kwargs,
+    llm: IndicLLMTransliterator | None = None,
+    **llm_kwargs: Any,
 ) -> list[Backend]:
     """Construct the backends for a chain, without running any of them.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ style = "google"
 arg-type-hints-in-docstring = false
 check-return-types = false
 check-class-attributes = false
+allow-init-docstring = true
 exclude = '\.venv|tests|docs|data|examples|scripts|notebooks|training'
 
 [tool.coverage.run]


### PR DESCRIPTION
## Why now

py-canon's reusable CI guards its pydoclint step with `[ -d src ]` and prints `no src/, skipping` otherwise. This repo is flat-layout, so its docstrings have never actually been checked — despite the standard claiming they are. [gojiplus/py-canon#8](https://github.com/gojiplus/py-canon/issues/8) fixes that guard.

This repo has **12 violations** today, so without this PR it goes red the moment that lands. Five of the six affected repos already pass; this is the sixth.

## Config drift — 5 of the 12

All five were `DOC301` (`__init__()` should not have a docstring). The template ships `allow-init-docstring = true` and this `pyproject.toml` had lost it. Restored — the docstrings were never the problem.

## Real fixes — 5 more

`llm`, `transliterator` and the `**kwargs` on the public entry points carried no type hints (`DOC106`/`DOC107`), and `EngineChain.convert` took Click's `value`/`param`/`ctx` untyped. `IndicLLMTransliterator` is imported under `TYPE_CHECKING`, so nothing new is imported at runtime.

## A judgement call — the last 2

`transliterate_batch` and `transliterate` each documented `UnsupportedPairError` under `Raises:`, but neither raises it — `resolve_pair` does, a frame or two down.

- pydoclint reads `Raises:` as *"what this body raises"* → `DOC502`/`DOC503`.
- This repo was using the other convention: *"what a caller can expect to catch."*

Both are defensible. pydoclint does not honour `# noqa: DOC502` — I tested it, and it flags the function regardless.

**I kept the information rather than deleting it**, moving it into prose just above `Returns:` and naming where the exception actually comes from:

```
Propagates ``UnsupportedPairError`` from :func:`transliterate_batch` when the
direction is unsupported or undetectable; it is not raised here.
```

If you would rather keep it under `Raises:`, the standard has an escape hatch for exactly this case — `run-pydoclint: false` in `ci.yml`, or `skip_checks` in `[tool.preen]`. Say the word and I will switch it.

## Verification

`ruff check`, `ruff format --check`, `pyright`, and `pydoclint` all clean; **397 tests pass**, 87 skipped (lookup tables not built locally).