### PR TITLE
Add Bengali lookup-only transliteration assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.9.0 — 2026-08-16
+
+### Added
+
+- Bengali-to-English is now a local lookup direction, including Eastern Nagari
+  words that use Assamese `ৰ` and `ৱ`. Its compiled `lookup.tsv.gz` downloads
+  from the pinned Hugging Face model-assets revision on first use. The source
+  corpus stays with its collection and provenance pipeline; millions of CSV
+  rows are not duplicated in this repository or the wheel.
+
+### Fixed
+
+- OpenAI Batch requests use `max_completion_tokens`. `max_tokens` is rejected
+  by current models such as `gpt-5.4-mini`, which previously made every request
+  in an otherwise valid batch fail before inference.
+- Lookup-only pairs no longer pretend to have seq2seq weights. Status reporting,
+  artifact checks, and `indicate info` now ask for model files only when the
+  direction actually supports the model backend.
+- Model assets are pinned to an immutable Hugging Face commit rather than a
+  moving branch or tag.
+
 ## 0.8.0 — 2026-08-14
 
 ### Changed — breaking

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,6 +6,6 @@ authors:
 - family-names: "Sood"
   given-names: "Gaurav"
 title: "Indicate: Transliterate Indic Languages to English"
-version: 0.1.0
-date-released: 2022-08-21
+version: 0.9.0
+date-released: 2026-08-16
 url: "https://github.com/in-rolls/indicate"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Indicate is a Python package for transliterating Indic text to English using PyTorch-based encoder-decoder models with attention. It ships local models for **Hindi** (Devanagari) and **Punjabi** (Gurmukhi), plus an LLM backend for other languages. The local models are custom-trained neural networks with pre-trained weights.
+Indicate is a Python package for transliterating Indic text to English using PyTorch-based encoder-decoder models with attention. It ships local models for **Hindi** (Devanagari) and **Punjabi** (Gurmukhi), a downloadable word lookup for **Bengali** (Eastern Nagari, including Assamese letters), and an LLM backend for other languages. The local models are custom-trained neural networks with pre-trained weights.
 
 ## Development Commands
 

--- a/Makefile
+++ b/Makefile
@@ -22,42 +22,42 @@ dev-install: ## Install package with development dependencies
 	pre-commit install
 
 test: ## Run tests
-	pytest
+	uv run pytest
 
 test-cov: ## Run tests with coverage
-	pytest --cov=indicate --cov-report=html --cov-report=term
+	uv run pytest --cov=indicate --cov-report=html --cov-report=term
 
 test-pkg: ## Test only the shipped package (skip gazetteer/, which does not ship)
-	pytest tests --ignore=tests/gazetteer
+	uv run pytest tests --ignore=tests/gazetteer
 
 test-contract: ## What must pass on a fresh clone with no network
-	HF_HUB_OFFLINE=1 pytest tests --ignore=tests/gazetteer
+	HF_HUB_OFFLINE=1 uv run pytest tests --ignore=tests/gazetteer
 
 test-artifacts: ## Fail instead of skipping when weights or tables are missing
-	pytest tests --require-artifacts
+	uv run pytest tests --require-artifacts
 
 test-e2e: ## Build the wheel, install it, run the console script
-	pytest -m "e2e and not live"
+	uv run pytest -m "e2e and not live"
 
 test-live: ## Reach Hugging Face and check the model repo has what we claim
-	pytest -m live
+	uv run pytest -m live
 
 build-lookup: ## Build both lookup tables from the committed corpora
 	uv run --group train python training/build_lookup.py --lang hindi
 	uv run --group train python training/build_lookup.py --lang punjabi
 
 lint: ## Run linter
-	ruff check .
+	uv run ruff check .
 
 format: ## Format code
-	ruff format .
-	ruff check --fix .
+	uv run ruff format .
+	uv run ruff check --fix .
 
 type-check: ## Run type checker
-	pyright
+	uv run pyright
 
 docs: ## Build documentation
-	cd docs && make clean && make html
+	uv run sphinx-build -W --keep-going -b html docs docs/_build/html
 
 docs-serve: ## Serve documentation locally
 	cd docs/build/html && python -m http.server 8000
@@ -69,7 +69,3 @@ upload: ## Upload to PyPI
 	uv publish
 
 ci: lint type-check test ## Run CI checks
-
-# Legacy aliases for compatibility
-install-dev: dev-install ## Legacy alias for dev-install
-typecheck: type-check ## Legacy alias for type-check

--- a/README.md
+++ b/README.md
@@ -50,13 +50,17 @@ pip install indicate
 # in the wheel. After the first run it works fully offline.
 ```
 
-### For the lookup backend (optional, and worth it):
+### For the lookup backend:
 
-The word table **does not ship in the wheel and is not downloadable**. It is
-derived from `data/hindi.csv.gz` (which blends CC-BY-NC IIT Bombay pairs) and
+The Bengali word table downloads from the pinned model-assets repository on
+first use and is then cached. It is compiled from a shared, LLM-labeled
+electoral-name corpus into one deterministic native-to-Latin lookup; the
+multi-million-row source CSV is not duplicated in this repository or package.
+
+Hindi and Punjabi tables are different: they derive from
+`data/hindi.csv.gz` (which blends CC-BY-NC IIT Bombay pairs) and
 `data/punjabi.csv.gz` (from a restricted electoral-roll deposit), neither of
-which is ours to redistribute under MIT. Build it from a checkout in a few
-seconds:
+which is ours to redistribute under MIT. Build those from a checkout:
 
 ```bash
 export INDICATE_DATA_DIR=~/.local/share/indicate     # where your tables live
@@ -71,12 +75,15 @@ looks first. Without it the table lands inside the checkout, which a
 
 ```
 Direction                 Backend   Status
+bengali -> english        lookup    downloads on first use
+                          llm       needs an API key
 punjabi -> english        lookup    ready
                           model     ready
 ```
 
-Without a table nothing breaks — `lookup` declines every word and `model`
-answers them.
+Without a Hindi or Punjabi table nothing breaks: `lookup` declines every word
+and `model` answers them. Bengali is lookup-only locally, so an unavailable
+table is reported as an error instead of silently returning blank text.
 
 ## 🎯 Usage
 
@@ -90,6 +97,9 @@ indicate transliterate "राजशेखर चिंतालपति"
 
 indicate transliterate "ਰਵਿ ਸ਼ਰਮਾ"
 # ravi sharma
+
+indicate transliterate "বৰুৱা"
+# barua
 
 # Devanagari carries several languages and detection picks Hindi, so say it
 # explicitly when it is not. Marathi has no local model — hence --engine llm
@@ -291,8 +301,8 @@ indicate transliterate --input names.txt --engine lookup
 
 | | `lookup` | `model` | `llm` |
 |---|---|---|---|
-| **Directions** | Hindi, Punjabi → English | Hindi, Punjabi → English | 12+ languages, any Indic pair |
-| **Setup** | build a table (one command) | none | API key |
+| **Directions** | Bengali, Hindi, Punjabi → English | Hindi, Punjabi → English | 12+ languages, any Indic pair |
+| **Setup** | Bengali downloads; build Hindi/Punjabi | none | API key |
 | **Speed** | 10,937 tok/s end to end | 258 tok/s | network-bound |
 | **Cost** | free | free | per API call |
 | **Offline** | ✅ | ✅ | ❌ |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export GOOGLE_API_KEY=your-key
 ```bash
 pip install indicate
 # No API key needed. The PyTorch weights are downloaded once from Hugging Face
-# (soodoku/indicate) on first transliterate and cached locally; tokenizers ship
+# (gojiberries/indicate) on first transliterate and cached locally; tokenizers ship
 # in the wheel. After the first run it works fully offline.
 ```
 

--- a/data/README.md
+++ b/data/README.md
@@ -71,6 +71,25 @@ data/<lang>.csv.gz (ours) + Aksharantar train/val (download)
   → training/train.py --rebuild-vocab → indicate/data/<lang>_to_english/
 ```
 
+**Bengali lookup**
+```
+shared LLM-labeled Eastern Nagari elector-name corpus
+  → deterministic, deduplicated lookup.tsv.gz
+  → pinned Hugging Face model-assets revision
+```
+
+Only the compiled lookup is published. The multi-million-row source CSV stays
+in `eroll_transliteration` with its collection and provenance pipeline; it is
+not copied into this repository or package. The compiled table header records
+the source corpus's SHA-256 for an exact, independently checkable build link.
+
+Rebuild the published artifact without copying the corpus:
+
+```bash
+uv run --group train python training/build_lookup.py --lang bengali \
+  --corpus ../eroll_transliteration/data/bengali.csv.gz
+```
+
 ## Reproduce / download
 
 ```bash

--- a/indicate/batch.py
+++ b/indicate/batch.py
@@ -396,7 +396,7 @@ def _submit_openai_jobs(
                 "model": model,
                 "messages": transliterator.build_group_messages(group, examples),
                 "temperature": temperature,
-                "max_tokens": transliterator.default_max_tokens_for(group),
+                "max_completion_tokens": transliterator.default_max_tokens_for(group),
             },
         }
         for cid, group in custom_id_to_tokens.items()

--- a/indicate/cli.py
+++ b/indicate/cli.py
@@ -405,6 +405,7 @@ def languages() -> None:
 @cli.command()
 def info() -> None:
     """Show information about the indicate package."""
+    from .languages import supports
     from .resources import HF_REPO, HF_REVISION
     from .transliterator import EMBEDDING_DIM, UNITS, model_for
 
@@ -426,6 +427,8 @@ def info() -> None:
     click.echo()
     click.echo(f"Weights: {HF_REPO}@{HF_REVISION} (Hugging Face; cached on first use)")
     for pair in PAIRS.values():
+        if not supports(pair.source, pair.target, "model"):
+            continue
         present = Path(model_for(pair).weights_dir).exists()
         state = "local copy present" if present else "downloaded on first use"
         click.echo(f"  {pair.source} -> {pair.target}: {state}")

--- a/indicate/languages.py
+++ b/indicate/languages.py
@@ -11,10 +11,11 @@ Two things live here and nothing else:
 **Languages** -- name, native spelling, script and ISO code, with the aliases
 callers actually type (``hi``, ``hin``, ``pan``).
 
-**Pairs** -- the ``(source, target)`` combinations a local seq2seq model exists
-for, and the files that model is made of. Replacing the old class-per-pair
-(``HindiToEnglish``, ``PunjabiToEnglish``) with data means adding a language is
-a dict entry rather than a module.
+**Pairs** -- the ``(source, target)`` combinations with local assets, and the
+directory that holds them. Some pairs have both a lookup and a seq2seq model;
+Bengali has a lookup only. Replacing the old class-per-pair
+(``HindiToEnglish``, ``PunjabiToEnglish``) with data means adding an asset is a
+registry entry rather than a module.
 
 Support is per *backend*, not global: ``("tamil", "english")`` is answerable by
 an LLM and by nothing else on this machine. :func:`supports` says so, and
@@ -128,7 +129,7 @@ INDIC_SCRIPTS = frozenset(SCRIPT_RANGES) - {"latin"}
 
 @dataclass(frozen=True, slots=True)
 class Pair:
-    """A direction a local seq2seq model exists for.
+    """A direction with at least one local asset.
 
     Attributes:
         source: Source language name.
@@ -139,6 +140,7 @@ class Pair:
         target_vocab: Target tokenizer filename.
         max_input: Longest source sequence the weights were trained for.
         max_output: Longest output sequence to decode.
+        has_model: Whether seq2seq weights exist for this direction.
     """
 
     source: str
@@ -148,6 +150,7 @@ class Pair:
     target_vocab: str
     max_input: int
     max_output: int
+    has_model: bool = True
 
     @property
     def key(self) -> tuple[str, str]:
@@ -158,6 +161,16 @@ class Pair:
 PAIRS: dict[tuple[str, str], Pair] = {
     pair.key: pair
     for pair in (
+        Pair(
+            source="bengali",
+            target="english",
+            subdir="bengali_to_english",
+            input_vocab="",
+            target_vocab="",
+            max_input=0,
+            max_output=0,
+            has_model=False,
+        ),
         Pair(
             source="hindi",
             target="english",
@@ -179,6 +192,10 @@ PAIRS: dict[tuple[str, str], Pair] = {
         ),
     )
 }
+
+#: Directions backed by seq2seq weights. Other entries in :data:`PAIRS` are
+#: lookup-only and must never make the model loader ask for nonexistent files.
+MODEL_PAIRS = frozenset(pair.key for pair in PAIRS.values() if pair.has_model)
 
 
 class UnknownLanguageError(ValueError):
@@ -381,7 +398,7 @@ def supports(source: str, target: str, backend: str) -> bool:
     if pair is None:
         return False
     if backend == "model":
-        return True
+        return pair.has_model
     if backend == "lookup":
         return _lookup_available(pair)
     return False

--- a/indicate/lookup.py
+++ b/indicate/lookup.py
@@ -74,23 +74,22 @@ FORMAT_VERSION = 1
 #:
 #: Membership means "look for it", not "it is there". Use :data:`DOWNLOADABLE`
 #: for the stronger claim.
-SHIPPED = frozenset({"hindi_to_english", "punjabi_to_english"})
+SHIPPED = frozenset({"bengali_to_english", "hindi_to_english", "punjabi_to_english"})
 
 #: Directories whose table can be fetched from the model repo.
 #:
-#: **Empty, and deliberately so.** The tables are derived from
+#: The Bengali table is derived entirely from LLM-labeled Eastern Nagari words
+#: and is published with the model assets. The Hindi and Punjabi tables are
+#: deliberately absent: they are derived from
 #: ``data/hindi.csv.gz`` (which blends CC-BY-NC IIT Bombay pairs) and
 #: ``data/punjabi.csv.gz`` (from the IRB-restricted electoral-roll deposit), so
 #: they are not ours to redistribute. Build one locally in a few seconds::
 #:
 #:     uv run --group train python training/build_lookup.py --lang punjabi
 #:
-#: Until this is non-empty, a fresh install has no lookup backend, and saying so
-#: here is what stops :func:`indicate.supported` advertising one. It also saves
-#: every fresh install a guaranteed-404 round trip per language per process.
-#: ``tests/e2e/test_hf_contract.py`` asserts that whatever is listed here is
-#: actually present in the repo.
-DOWNLOADABLE: frozenset[str] = frozenset()
+#: ``tests/e2e/test_hf_contract.py`` asserts that every listed table is present
+#: at the pinned repository revision, and that no unlisted table is published.
+DOWNLOADABLE: frozenset[str] = frozenset({"bengali_to_english"})
 
 _HEADER_PREFIX = "#"
 _CACHE: dict[str, Lookup | None] = {}
@@ -286,8 +285,8 @@ class Lookup:
         if subdir not in SHIPPED:
             _CACHE[subdir] = None
             return None
-        # A local build is the normal case. Only reach for the network when the
-        # table is actually published, which today is never -- see DOWNLOADABLE.
+        # A local build is the normal case for restricted corpora. Only reach
+        # for the network when the table is explicitly published.
         local = local_data_path(subdir, LOOKUP_FILE)
         path = (
             local

--- a/indicate/resources.py
+++ b/indicate/resources.py
@@ -16,7 +16,7 @@ from importlib.resources import files
 
 #: Hugging Face repo holding per-language directories.
 HF_REPO = "gojiberries/indicate"
-HF_REVISION = "bfe94dbf0daae72e8aada28ba6dd435a213cc365"
+HF_REVISION = "0f52f329600dbf1a5be7504e3a8e616948cd6cfa"
 
 
 #: Environment variable naming a directory to look in before the package.

--- a/indicate/resources.py
+++ b/indicate/resources.py
@@ -15,8 +15,8 @@ import os
 from importlib.resources import files
 
 #: Hugging Face repo holding per-language directories.
-HF_REPO = "soodoku/indicate"
-HF_REVISION = "v0.7.0"
+HF_REPO = "gojiberries/indicate"
+HF_REVISION = "bfe94dbf0daae72e8aada28ba6dd435a213cc365"
 
 
 #: Environment variable naming a directory to look in before the package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ exclude_lines = [
 [tool.pyright]
 include = ["indicate", "gazetteer"]
 typeCheckingMode = "standard"
+venvPath = "."
+venv = ".venv"
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from indicate.languages import PAIRS  # noqa: E402
-from indicate.lookup import LOOKUP_FILE  # noqa: E402
+from indicate.languages import PAIRS, supports  # noqa: E402
+from indicate.lookup import DOWNLOADABLE, LOOKUP_FILE  # noqa: E402
 from indicate.resources import HF_REPO, HF_REVISION, local_data_path  # noqa: E402
 from indicate.transliterator import DECODER_FILE, ENCODER_FILE  # noqa: E402
 
@@ -104,9 +104,11 @@ def _missing() -> dict[str, list[str]]:
     """Return the missing artifacts, keyed by kind, as language names."""
     missing: dict[str, list[str]] = {"lookup": [], "weights": []}
     for pair in PAIRS.values():
-        if not lookup_available(pair.subdir):
+        if pair.subdir not in DOWNLOADABLE and not lookup_available(pair.subdir):
             missing["lookup"].append(pair.source)
-        if not weights_available(pair.subdir):
+        if supports(pair.source, pair.target, "model") and not weights_available(
+            pair.subdir
+        ):
             missing["weights"].append(pair.source)
     return missing
 

--- a/tests/e2e/test_console_script.py
+++ b/tests/e2e/test_console_script.py
@@ -106,7 +106,7 @@ class TestInfoCommand:
     ):
         proc = run(script, "info", env=clean_env, cwd=tmp_path)
         assert proc.returncode == 0, proc.stderr
-        assert "soodoku/indicate" in proc.stdout
+        assert "gojiberries/indicate" in proc.stdout
         assert "hindi -> english" in proc.stdout
 
 

--- a/tests/e2e/test_console_script.py
+++ b/tests/e2e/test_console_script.py
@@ -81,11 +81,11 @@ class TestLanguagesCommand:
         proc = run(script, "languages", env=clean_env, cwd=tmp_path)
         assert proc.returncode == 0, proc.stderr
 
-    def test_it_reports_the_lookup_backend_as_unavailable_here(
+    def test_it_distinguishes_downloadable_and_locally_built_lookups(
         self, script: Path, clean_env, tmp_path: Path
     ):
-        # This venv has no lookup table and none can be fetched. Advertising it
-        # as available is what made engine=["lookup"] return empty strings.
+        # This venv has no lookup tables. Bengali is published and can be
+        # fetched later; the restricted Hindi and Punjabi tables cannot.
         proc = run(script, "languages", env=clean_env, cwd=tmp_path)
         assert proc.returncode == 0, proc.stderr
         # Table rows only: the trailing hint also mentions the word "lookup".
@@ -96,7 +96,12 @@ class TestLanguagesCommand:
             if line.rstrip().endswith(("ready", "unavailable", "first use"))
         ]
         assert rows, proc.stdout
-        assert all(row.endswith("unavailable") for row in rows), rows
+        by_language = {
+            row.split(" ->", 1)[0].strip(): row for row in rows if " ->" in row
+        }
+        assert by_language["bengali"].endswith("downloads on first use")
+        assert by_language["hindi"].endswith("unavailable")
+        assert by_language["punjabi"].endswith("unavailable")
         assert "build_lookup.py" in proc.stdout
 
 

--- a/tests/e2e/test_hf_contract.py
+++ b/tests/e2e/test_hf_contract.py
@@ -4,7 +4,8 @@ Marked ``live`` and deselected by default, so an ordinary ``pytest`` run never
 touches the network. Run it with ``-m live``, on a schedule and on release tags.
 
 This exists because the answer was **no**. ``indicate/lookup.py`` resolves
-``<pair>/lookup.tsv.gz`` from ``soodoku/indicate@v0.7.0``; that path 404s for
+``<pair>/lookup.tsv.gz`` from the pinned ``gojiberries/indicate`` revision;
+that path 404s for
 both languages while the weights return 200. Every installed user got an empty
 string from ``engine=["lookup"]``, silently, and nothing in the suite noticed
 because every test ran against a checkout that had the tables locally.

--- a/tests/e2e/test_hf_contract.py
+++ b/tests/e2e/test_hf_contract.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import pytest
 
-from indicate.languages import PAIRS
+from indicate.languages import PAIRS, supports
 from indicate.lookup import DOWNLOADABLE, LOOKUP_FILE
 from indicate.resources import HF_REPO, HF_REVISION
 from indicate.transliterator import DECODER_FILE, ENCODER_FILE
@@ -51,7 +51,11 @@ def test_the_pinned_revision_exists(repo_files: set[str]):
     assert repo_files, f"{HF_REPO}@{HF_REVISION} is empty or missing"
 
 
-@pytest.mark.parametrize("pair", list(PAIRS.values()), ids=lambda p: p.subdir)
+@pytest.mark.parametrize(
+    "pair",
+    [pair for pair in PAIRS.values() if supports(*pair.key, "model")],
+    ids=lambda p: p.subdir,
+)
 def test_every_weight_the_loader_requests_is_present(pair, repo_files: set[str]):
     for rel in (ENCODER_FILE, DECODER_FILE):
         assert f"{pair.subdir}/{rel}" in repo_files, (
@@ -62,9 +66,8 @@ def test_every_weight_the_loader_requests_is_present(pair, repo_files: set[str])
 
 @pytest.mark.parametrize("pair", list(PAIRS.values()), ids=lambda p: p.subdir)
 def test_every_lookup_table_the_code_claims_is_present(pair, repo_files: set[str]):
-    # DOWNLOADABLE is the code's claim that a table can be fetched. It is empty
-    # today because the tables are not ours to redistribute; if anything is ever
-    # added to it, this is what checks the upload actually happened.
+    # DOWNLOADABLE is the code's claim that a table can be fetched. This checks
+    # the upload actually happened before a release advertises it.
     if pair.subdir not in DOWNLOADABLE:
         pytest.skip(
             f"{pair.subdir} is not in lookup.DOWNLOADABLE; the package does not "

--- a/tests/e2e/test_offline_fresh_clone.py
+++ b/tests/e2e/test_offline_fresh_clone.py
@@ -27,7 +27,7 @@ import sys
 
 import pytest
 
-from indicate.languages import PAIRS
+from indicate.languages import PAIRS, supports
 from indicate.lookup import LOOKUP_FILE
 from indicate.resources import local_data_path
 from indicate.transliterator import ENCODER_FILE
@@ -41,7 +41,10 @@ def _artifacts_in_source_tree() -> list[str]:
     """Return the artifact paths a checkout provides, which env vars cannot hide."""
     present = []
     for pair in PAIRS.values():
-        for rel in (LOOKUP_FILE, ENCODER_FILE):
+        rels = [LOOKUP_FILE]
+        if supports(*pair.key, "model"):
+            rels.append(ENCODER_FILE)
+        for rel in rels:
             path = local_data_path(pair.subdir, rel)
             if os.path.exists(path):
                 present.append(path)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -132,6 +132,9 @@ class TestSubmit(BatchTestBase):
         # The submitted JSONL request carries those tokens.
         (file_requests,) = fake.input_files.values()
         self.assertEqual(_tokens_in_request(file_requests[0]), ["ਰਾਜ", "ਪੰਜਾਬ", "ਸਿੰਘ"])
+        body = file_requests[0]["body"]
+        self.assertIn("max_completion_tokens", body)
+        self.assertNotIn("max_tokens", body)
 
     def test_submit_skips_already_resolved(self):
         # Pre-populate the resolved checkpoint with one token.

--- a/tests/test_bengali_lookup.py
+++ b/tests/test_bengali_lookup.py
@@ -1,0 +1,32 @@
+"""Bengali is a downloadable lookup direction, not a pretend local model."""
+
+from unittest.mock import patch
+
+import indicate
+from indicate.engine import LookupBackend, build
+from indicate.languages import PAIRS, supported, supports
+from indicate.lookup import Lookup, lookup_key
+
+BN = PAIRS[("bengali", "english")]
+BARUA = "বৰুৱা"
+
+
+def _table() -> Lookup:
+    return Lookup({lookup_key(BARUA): "barua"}, {"convention": "roll"})
+
+
+def test_bengali_is_lookup_only():
+    assert supports("bengali", "english", "lookup")
+    assert not supports("bengali", "english", "model")
+    assert supported()[BN.key] == ("lookup", "llm")
+
+
+def test_default_chain_does_not_construct_a_model_backend():
+    backends = build(None, BN)
+    assert len(backends) == 1
+    assert isinstance(backends[0], LookupBackend)
+
+
+def test_assamese_letters_route_through_the_bengali_lookup():
+    with patch("indicate.lookup.Lookup.load", return_value=_table()):
+        assert indicate.transliterate(BARUA) == "barua"

--- a/tests/test_build_lookup.py
+++ b/tests/test_build_lookup.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import csv
+import gzip
+import hashlib
 import sys
+import tempfile
 import unittest
 from collections import Counter
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from training.build_lookup import choose, is_implausible
+from indicate.lookup import Lookup
+from training.build_lookup import choose, is_implausible, main
 
 
 class TestPlausibility(unittest.TestCase):
@@ -59,6 +64,44 @@ class TestChoose(unittest.TestCase):
         forward = choose("कुमार", Counter({"kumar": 408, "r": 1}))
         backward = choose("कुमार", Counter({"r": 1, "kumar": 408}))
         self.assertEqual(forward, backward)
+
+
+class TestExternalCorpus(unittest.TestCase):
+    def test_bengali_compiles_without_copying_the_source_corpus(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            corpus = root / "bengali.csv.gz"
+            with gzip.open(corpus, "wt", encoding="utf-8", newline="") as handle:
+                writer = csv.writer(handle)
+                writer.writerow(("bengali", "english"))
+                writer.writerow(("বৰুৱা", "barua"))
+            output = root / "lookup.tsv.gz"
+
+            status = main(
+                [
+                    "--lang",
+                    "bengali",
+                    "--corpus",
+                    str(corpus),
+                    "--out",
+                    str(output),
+                ]
+            )
+
+            self.assertEqual(status, 0)
+            table = Lookup.from_path(output)
+            assert table is not None
+            self.assertEqual(table.get("বৰুৱা"), "barua")
+            self.assertEqual(
+                table.meta["source"], "eroll_transliteration/data/bengali.csv.gz"
+            )
+            self.assertEqual(
+                table.meta["source_sha256"],
+                hashlib.sha256(corpus.read_bytes()).hexdigest(),
+            )
+
+    def test_bengali_names_the_missing_external_input(self):
+        self.assertEqual(main(["--lang", "bengali"]), 1)
 
 
 ROOT = Path(__file__).resolve().parent.parent

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -6,6 +6,7 @@ import unittest
 
 from indicate.languages import (
     LANGUAGES,
+    MODEL_PAIRS,
     PAIRS,
     SCRIPT_TO_LANGUAGE,
     UnknownLanguageError,
@@ -76,6 +77,8 @@ class TestSupport(unittest.TestCase):
         self.assertTrue(supports("punjabi", "english", "model"))
 
     def test_a_pair_with_no_local_model_does_not(self):
+        self.assertFalse(supports("bengali", "english", "model"))
+        self.assertTrue(supports("bengali", "english", "lookup"))
         self.assertFalse(supports("tamil", "english", "model"))
         self.assertFalse(supports("tamil", "english", "lookup"))
 
@@ -93,7 +96,7 @@ class TestSupport(unittest.TestCase):
         self.assertIn("llm", table[("tamil", "english")])
 
     def test_supported_can_be_restricted_to_one_backend(self):
-        self.assertEqual(set(supported("model")), set(PAIRS))
+        self.assertEqual(set(supported("model")), set(MODEL_PAIRS))
 
 
 class TestResolvePair(unittest.TestCase):

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -4,8 +4,9 @@ import gzip
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from indicate.lookup import Lookup
+from indicate.lookup import LOOKUP_FILE, Lookup, clear_cache
 
 GURMUKHI_SINGH = "ਸਿੰਘ"
 GURMUKHI_KAUR = "ਕੌਰ"
@@ -113,6 +114,9 @@ class TestGet(unittest.TestCase):
 
 
 class TestCaching(unittest.TestCase):
+    def tearDown(self):
+        clear_cache()
+
     def test_load_caches_by_subdir(self):
         first = Lookup.load("punjabi_to_english")
         second = Lookup.load("punjabi_to_english")
@@ -120,6 +124,28 @@ class TestCaching(unittest.TestCase):
 
     def test_load_of_an_unknown_subdir_is_none(self):
         self.assertIsNone(Lookup.load("no_such_language_to_english"))
+
+    def test_bengali_table_is_resolved_from_the_pinned_asset_repo(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            table_path = _write_table(Path(tmp), (("বৰুৱা", "barua"),))
+            with (
+                patch("indicate.lookup.local_data_path", return_value="/missing"),
+                patch(
+                    "indicate.lookup.try_resolve_data", return_value=str(table_path)
+                ) as resolve,
+            ):
+                table = Lookup.load("bengali_to_english")
+
+        self.assertEqual(table.get("বৰুৱা"), "barua")
+        resolve.assert_called_once_with("bengali_to_english", LOOKUP_FILE)
+
+    def test_restricted_tables_do_not_attempt_a_download(self):
+        with (
+            patch("indicate.lookup.local_data_path", return_value="/missing"),
+            patch("indicate.lookup.try_resolve_data") as resolve,
+        ):
+            self.assertIsNone(Lookup.load("hindi_to_english"))
+        resolve.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_lookup_bench.py
+++ b/tests/test_lookup_bench.py
@@ -93,6 +93,7 @@ def _rss_mb() -> float:
 
 @unittest.skipUnless(_table_available(), "punjabi lookup table not built")
 class TestLookupPerformance(unittest.TestCase):
+    @pytest.mark.no_cover
     def test_table_loads_quickly_and_cheaply(self):
         clear_cache()
         before = _rss_mb()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -81,17 +81,16 @@ def test_a_missing_file_is_requested_by_its_exact_repo_path(no_local):
     # Positional args and the revision keyword, spelled out. A rename on either
     # side of this join is a 404 that only shows up at runtime.
     download.assert_called_once_with(
-        "soodoku/indicate",
+        "gojiberries/indicate",
         "hindi_to_english/saved_weights/encoder.safetensors",
         revision=HF_REVISION,
     )
 
 
-def test_the_revision_is_pinned_to_a_tag(no_local):
-    # A moving ref means an upstream commit can change what users get without
-    # any release here. Tags are immutable; branches are not.
-    assert HF_REVISION not in {"main", "master", "HEAD", None}
-    assert HF_REPO == "soodoku/indicate"
+def test_the_revision_is_an_immutable_commit(no_local):
+    assert len(HF_REVISION) == 40
+    assert set(HF_REVISION) <= set("0123456789abcdef")
+    assert HF_REPO == "gojiberries/indicate"
 
 
 def test_an_override_repo_and_revision_are_honoured(no_local):

--- a/training/build_lookup.py
+++ b/training/build_lookup.py
@@ -1,9 +1,11 @@
-"""Build the word-level lookup table from a committed training corpus.
+"""Build the word-level lookup table from a configured training corpus.
 
 Run::
 
     uv run python training/build_lookup.py --lang punjabi
     uv run python training/build_lookup.py --lang hindi
+    uv run python training/build_lookup.py --lang bengali \
+        --corpus ../eroll_transliteration/data/bengali.csv.gz
     uv run python training/build_lookup.py --lang punjabi --eval-clean
 
 Writes ``indicate/data/<lang>_to_english/lookup.tsv.gz``.
@@ -38,6 +40,7 @@ from __future__ import annotations
 import argparse
 import csv
 import gzip
+import hashlib
 import os
 import sys
 from collections import Counter, defaultdict
@@ -57,6 +60,14 @@ MAX_RATIO = 4.0
 
 #: Per-language source corpus, its columns, and the convention it speaks.
 CORPORA = {
+    "bengali": {
+        "path": None,
+        "source": "eroll_transliteration/data/bengali.csv.gz",
+        "native": "bengali",
+        "latin": "english",
+        "convention": "roll",
+        "subdir": "bengali_to_english",
+    },
     "punjabi": {
         "path": "data/punjabi.csv.gz",
         "native": "punjabi",
@@ -241,6 +252,15 @@ def write_table(path: Path, table: dict[str, str], meta: dict[str, str]) -> int:
     return path.stat().st_size
 
 
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of ``path`` without loading it into memory."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def main(argv: list[str] | None = None) -> int:
     """Build and write one language's lookup table.
 
@@ -253,6 +273,15 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--lang", required=True, choices=sorted(CORPORA))
     parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=None,
+        help=(
+            "external corpus path; required when the language corpus is not "
+            "committed here"
+        ),
+    )
+    parser.add_argument(
         "--eval-clean",
         action="store_true",
         help="exclude eval-set source words, for honest benchmarking",
@@ -261,7 +290,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     spec = CORPORA[args.lang]
-    corpus = REPO_ROOT / spec["path"]
+    corpus = args.corpus
+    if corpus is None and spec["path"] is not None:
+        corpus = REPO_ROOT / spec["path"]
+    if corpus is None:
+        print(f"{args.lang}: --corpus is required", file=sys.stderr)
+        return 1
     if not corpus.is_file():
         print(f"missing corpus: {corpus}", file=sys.stderr)
         return 1
@@ -288,7 +322,8 @@ def main(argv: list[str] | None = None) -> int:
         "normalizer": str(NORMALIZER_VERSION),
         "lang": args.lang,
         "convention": spec["convention"],
-        "source": spec["path"],
+        "source": spec.get("source") or spec["path"],
+        "source_sha256": sha256_file(corpus),
         "entries": str(len(table)),
         "eval_clean": "1" if args.eval_clean else "0",
     }


### PR DESCRIPTION
Summary:
- add Bengali-to-English as a lookup-only direction backed by the compiled immutable HF asset
- keep the canonical Bengali corpus external and build the lookup from an explicit corpus path with SHA-256 provenance
- fix OpenAI Batch requests for current models and cover lookup-only contracts with tests

Verification:
- uv run ruff check .
- uv run pyright
- uv run pytest --require-artifacts
- docs build with warnings as errors
- clean-cache Bengali lookup download resolves Bengali Barua to barua

The Bengali asset is published at HF revision 0f52f329600dbf1a5be7504e3a8e616948cd6cfa.